### PR TITLE
Fix broken embedded image in readme

### DIFF
--- a/Season 2/Episode 1 - Hack your plant/hackyourplant/readme.md
+++ b/Season 2/Episode 1 - Hack your plant/hackyourplant/readme.md
@@ -14,7 +14,7 @@ This example will allow you collect data from your plant and give you notificati
 
 ## Wiring
 ##### Connect the wires and components according to the fritzing below.
-![alt text](https://github.com/arduino/livecast/raw/master/Season%202/Episode%201%20-%20Hack%20your%20plant/episode1_fritzing.png "Logo Title Text 1")
+![alt text](episode1_fritzing.png "Logo Title Text 1")
 
 
 


### PR DESCRIPTION
The move of the files to a sketch folder broke the image.

Sorry about that. I should have thought to check whether the image link was absolute.